### PR TITLE
Scale line width when rasterizing paths

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -214,3 +214,10 @@ func (t Matrix2D) QuadTo(m OpQuadTo) (fixed.Point26_6, fixed.Point26_6) {
 func (t Matrix2D) CubicTo(m OpCubicTo) (fixed.Point26_6, fixed.Point26_6, fixed.Point26_6) {
 	return t.TFixed(fixed.Point26_6(m[0])), t.TFixed(fixed.Point26_6(m[1])), t.TFixed(fixed.Point26_6(m[2]))
 }
+
+// LineWidthScale returns the mean of the horizontal and vertical scaling members.
+// It may be used when scaling line widths with a rasterizer that does not support
+// scaling a line's horizontal and vertical aspects independently.
+func (t Matrix2D) LineWidthScale() float64 {
+	return (t.A + t.D) / 2
+}

--- a/renderer/draw2d/draw.go
+++ b/renderer/draw2d/draw.go
@@ -97,8 +97,7 @@ func drawTransformed(gc draw2d.GraphicContext, svgp svg.SvgPath, opt *renderer.R
 		case svg.Gradient:
 			gc.SetStrokeColor(toGradient(c, svgp.Style.LineOpacity*opt.Opacity))
 		}
-		scale := (m.A + m.D) / 2
-		gc.SetLineWidth(svgp.Style.LineWidth * scale)
+		gc.SetLineWidth(svgp.Style.LineWidth * m.LineWidthScale())
 		gc.SetLineDash(svgp.Style.Dash.Dash, svgp.Style.Dash.DashOffset)
 	}
 

--- a/renderer/draw2d/draw.go
+++ b/renderer/draw2d/draw.go
@@ -97,7 +97,8 @@ func drawTransformed(gc draw2d.GraphicContext, svgp svg.SvgPath, opt *renderer.R
 		case svg.Gradient:
 			gc.SetStrokeColor(toGradient(c, svgp.Style.LineOpacity*opt.Opacity))
 		}
-		gc.SetLineWidth(svgp.Style.LineWidth)
+		scale := (m.A + m.D) / 2
+		gc.SetLineWidth(svgp.Style.LineWidth * scale)
 		gc.SetLineDash(svgp.Style.Dash.Dash, svgp.Style.Dash.DashOffset)
 	}
 

--- a/renderer/gg/draw.go
+++ b/renderer/gg/draw.go
@@ -129,7 +129,8 @@ func drawTransformed(gc *gg.Context, s *svg.Svg, svgp svg.SvgPath, m svg.Matrix2
 		case svg.Gradient:
 			gc.SetColor(toColor(svg.GetColor(c), svgp.Style.LineOpacity*opacity))
 		}
-		gc.SetLineWidth(svgp.Style.LineWidth)
+		scale := (m.A + m.D) / 2
+		gc.SetLineWidth(svgp.Style.LineWidth * scale)
 		gc.SetDash(svgp.Style.Dash.Dash...)
 		gc.SetDashOffset(svgp.Style.Dash.DashOffset)
 	}

--- a/renderer/gg/draw.go
+++ b/renderer/gg/draw.go
@@ -129,8 +129,7 @@ func drawTransformed(gc *gg.Context, s *svg.Svg, svgp svg.SvgPath, m svg.Matrix2
 		case svg.Gradient:
 			gc.SetColor(toColor(svg.GetColor(c), svgp.Style.LineOpacity*opacity))
 		}
-		scale := (m.A + m.D) / 2
-		gc.SetLineWidth(svgp.Style.LineWidth * scale)
+		gc.SetLineWidth(svgp.Style.LineWidth * m.LineWidthScale())
 		gc.SetDash(svgp.Style.Dash.Dash...)
 		gc.SetDashOffset(svgp.Style.Dash.DashOffset)
 	}

--- a/renderer/rasterx/draw.go
+++ b/renderer/rasterx/draw.go
@@ -152,10 +152,11 @@ func drawTransformed(gc *rasterx.Dasher, svgp svg.SvgPath, opt *renderer.RenderO
 		filler.Draw()
 	}
 	if svgp.Style.LinerColor != nil {
+		scale := (m.A + m.D) / 2
 		stroker := &gc.Stroker
 		stroker.Clear()
 		stroker.SetStroke(
-			fixed.Int26_6(svgp.Style.LineWidth*64),
+			fixed.Int26_6(svgp.Style.LineWidth*64*scale),
 			svgp.Style.Join.MiterLimit,
 			toLineCap(svgp.Style.Join.LeadLineCap, toLineCap(svgp.Style.Join.TrailLineCap, rasterx.ButtCap)),
 			toLineCap(svgp.Style.Join.TrailLineCap, rasterx.ButtCap),

--- a/renderer/rasterx/draw.go
+++ b/renderer/rasterx/draw.go
@@ -152,11 +152,10 @@ func drawTransformed(gc *rasterx.Dasher, svgp svg.SvgPath, opt *renderer.RenderO
 		filler.Draw()
 	}
 	if svgp.Style.LinerColor != nil {
-		scale := (m.A + m.D) / 2
 		stroker := &gc.Stroker
 		stroker.Clear()
 		stroker.SetStroke(
-			fixed.Int26_6(svgp.Style.LineWidth*64*scale),
+			fixed.Int26_6(svgp.Style.LineWidth*64*m.LineWidthScale()),
 			svgp.Style.Join.MiterLimit,
 			toLineCap(svgp.Style.Join.LeadLineCap, toLineCap(svgp.Style.Join.TrailLineCap, rasterx.ButtCap)),
 			toLineCap(svgp.Style.Join.TrailLineCap, rasterx.ButtCap),


### PR DESCRIPTION
This is an svg rendered using with the rasterx renderer, before the change.
![before](https://github.com/user-attachments/assets/e67ea869-fcee-4af4-b347-6b82aefe6580)

And this is the result after the change. 
![after](https://github.com/user-attachments/assets/7f70a2fc-2b98-44c8-954e-1f5b171fada4)
See #8 for the original svg used.

I don't particularly like the way that I'm using mean of the x and y scaling for a scaling factor, but I'm not sure what a better approach would be. From a bit of experimentation browsers appear to be able to scale stroke width for x and y independently. That is horizontal sections of a path have a width that has y scaling applied, and vertical sections have a width with x scaling applied.

I don't believe that any of the supported renderers have any support for drawing strokes with independent x and y thickness scaling. Hence my simplistic approach.  I'm open to suggestions if there's a better way. In any case I think that this is an improvement on the current rendering.

fixes #8 